### PR TITLE
Add a command line version with args

### DIFF
--- a/disc.py
+++ b/disc.py
@@ -9,7 +9,7 @@ parser = argparse.ArgumentParser(description="Store all inputs in a single list.
 parser.add_argument("ext", nargs="*", help="The extenstions you want to search for, serperated by a space")
 
 # Add a flag that appends a value to the list
-parser.add_argument("-path", "--path", action="store_true", help="search all directories in path too?")
+parser.add_argument("-p", "--path", action="store_true", help="search all directories in path too?")
 
 # Parse the arguments
 args = parser.parse_args()

--- a/disc.py
+++ b/disc.py
@@ -1,17 +1,19 @@
 #!/bin/python3
 
 import argparse,discover
+try:
+    # Create the parser
+    parser = argparse.ArgumentParser(description="Store all inputs in a single list.")
 
-# Create the parser
-parser = argparse.ArgumentParser(description="Store all inputs in a single list.")
+    # Add a list argument
+    parser.add_argument("ext", nargs="*", help="The extenstions you want to search for, serperated by a space")
 
-# Add a list argument
-parser.add_argument("ext", nargs="*", help="The extenstions you want to search for, serperated by a space")
+    # Add a flag that appends a value to the list
+    parser.add_argument("-p", "--path", action="store_true", help="search all directories in path too?")
 
-# Add a flag that appends a value to the list
-parser.add_argument("-p", "--path", action="store_true", help="search all directories in path too?")
+    # Parse the arguments
+    args = parser.parse_args()
 
-# Parse the arguments
-args = parser.parse_args()
-
-discover.discover(args.ext, args.path)
+    discover.discover(args.ext, args.path)
+except KeyboardInterrupt:
+    print("KeyboardInterrupt detected")

--- a/disc.py
+++ b/disc.py
@@ -1,0 +1,17 @@
+#!/bin/python3
+
+import argparse,discover
+
+# Create the parser
+parser = argparse.ArgumentParser(description="Store all inputs in a single list.")
+
+# Add a list argument
+parser.add_argument("ext", nargs="*", help="The extenstions you want to search for, serperated by a space")
+
+# Add a flag that appends a value to the list
+parser.add_argument("-path", "--path", action="store_true", help="search all directories in path too?")
+
+# Parse the arguments
+args = parser.parse_args()
+
+discover.discover(args.ext, args.path)


### PR DESCRIPTION
usage: ./disc.py [-h] [-p] [ext ...]

Store all inputs in a single list.

positional arguments:
  ext         The extenstions you want to search for, serperated by a space

options:
  -h, --help  show this help message and exit
  -p, --path  search all directories in path too?